### PR TITLE
Move installed binaries out of $CARGO_HOME

### DIFF
--- a/1.22.1/stretch/Dockerfile
+++ b/1.22.1/stretch/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
     chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --default-toolchain 1.22.1; \
     rm rustup-init; \
+    mv $CARGO_HOME/bin/* /usr/local/bin/; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \


### PR DESCRIPTION
This is a one-line fix for #17. The binaries, plus an `env` file which is only meaningful when `$CARGO_HOME` is populated with binaries, are all that is installed there by the Docker image build.

If a container run invokes rustup, this may override the binaries
moved to `/usr/local/bin` with freshly installed binaries in `$CARGO_HOME/bin/`.
This is perfectly fine for incremental container images.